### PR TITLE
Edflex component: check how the synchronizations are scheduled

### DIFF
--- a/edflex/tasks.py
+++ b/edflex/tasks.py
@@ -1,6 +1,4 @@
 import logging
-from celery.decorators import periodic_task
-from celery.schedules import crontab
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
@@ -23,42 +21,7 @@ from .utils import (
 
 log = logging.getLogger('edflex_xblock')
 
-# default 'At 01:00 on day-of-month 1'
-EDFLEX_RESOURCES_UPDATE_CRON = settings.XBLOCK_SETTINGS.get('EdflexXBlock', {}).get('EDFLEX_RESOURCES_UPDATE_CRON', {})
-update_resources_cron = {
-    'minute': str(EDFLEX_RESOURCES_UPDATE_CRON.get('MINUTE', '0')),
-    'hour': str(EDFLEX_RESOURCES_UPDATE_CRON.get('HOUR', '1')),
-    'day_of_month': str(EDFLEX_RESOURCES_UPDATE_CRON.get('DAY_OF_MONTH', '1')),
-    'month_of_year': str(EDFLEX_RESOURCES_UPDATE_CRON.get('MONTH_OF_YEAR', '*')),
-    'day_of_week': str(EDFLEX_RESOURCES_UPDATE_CRON.get('DAY_OF_WEEK', '*')),
-}
 
-# default 'At 01:00 on Monday'
-EDFLEX_RESOURCES_FETCH_CRON = settings.XBLOCK_SETTINGS.get('EdflexXBlock', {}).get('EDFLEX_RESOURCES_FETCH_CRON', {})
-fetch_edflex_data_cron = {
-    'minute': str(EDFLEX_RESOURCES_FETCH_CRON.get('MINUTE', '0')),
-    'hour': str(EDFLEX_RESOURCES_FETCH_CRON.get('HOUR', '1')),
-    'day_of_month': str(EDFLEX_RESOURCES_FETCH_CRON.get('DAY_OF_MONTH', '*')),
-    'month_of_year': str(EDFLEX_RESOURCES_FETCH_CRON.get('MONTH_OF_YEAR', '*')),
-    'day_of_week': str(EDFLEX_RESOURCES_FETCH_CRON.get('DAY_OF_WEEK', '1')),
-}
-
-# default 'At minute 0 past every hour.'
-EDFLEX_NEW_RESOURCES_FETCH_CRON = settings.XBLOCK_SETTINGS.get(
-    'EdflexXBlock', {}
-).get(
-    'EDFLEX_NEW_RESOURCES_FETCH_CRON', {}
-)
-fetch_new_edflex_data_cron = {
-    'minute': str(EDFLEX_RESOURCES_FETCH_CRON.get('MINUTE', '0')),
-    'hour': str(EDFLEX_RESOURCES_FETCH_CRON.get('HOUR', '*/1')),
-    'day_of_month': str(EDFLEX_RESOURCES_FETCH_CRON.get('DAY_OF_MONTH', '*')),
-    'month_of_year': str(EDFLEX_RESOURCES_FETCH_CRON.get('MONTH_OF_YEAR', '*')),
-    'day_of_week': str(EDFLEX_RESOURCES_FETCH_CRON.get('DAY_OF_WEEK', '*')),
-}
-
-
-@periodic_task(run_every=crontab(**fetch_edflex_data_cron))
 def fetch_edflex_data():
     if EDFLEX_CLIENT_ID and EDFLEX_CLIENT_SECRET and EDFLEX_BASE_API_URL:
         fetch_resources(EDFLEX_CLIENT_ID, EDFLEX_CLIENT_SECRET, EDFLEX_LOCALE, EDFLEX_BASE_API_URL)
@@ -73,7 +36,6 @@ def fetch_edflex_data():
             fetch_resources(client_id, client_secret, locale, base_api_url)
 
 
-@periodic_task(run_every=crontab(**fetch_new_edflex_data_cron))
 def fetch_new_edflex_data():
     if EDFLEX_CLIENT_ID and EDFLEX_CLIENT_SECRET and EDFLEX_BASE_API_URL:
         fetch_new_resources_and_delete_old_resources(
@@ -93,7 +55,6 @@ def fetch_new_edflex_data():
             fetch_new_resources_and_delete_old_resources(client_id, client_secret, locale, base_api_url)
 
 
-@periodic_task(run_every=crontab(**update_resources_cron))
 def update_resources():
     user = get_user_model().objects.filter(
         Q(is_staff=True) | Q(is_superuser=True), is_active=True


### PR DESCRIPTION
Task: https://trello.com/c/vAi0p28B

Removed `periodic_task` from the code.  Then `celerybeat` would never trigger them again.

For making sure these changes would not affect anything, tested commands in staging as follow:
```
Already deployed on staging:
edxapp@learning-tribes:~/venvs/edxapp/src/edflex-xblock/edflex$ git status
On branch barry-hawthorn
Your branch is up-to-date with 'origin/barry-hawthorn'.
```
```
edxapp@learning-tribes:~/edx-platform$ python manage.py lms fetch_new_edflex_data
2021-03-09 23:56:55,699 INFO 20576 [edflex_xblock] fetch_new_edflex_data.py:26 - Starting fetching the new edflex data...
2021-03-09 23:57:06,192 INFO 20576 [edflex_xblock] fetch_new_edflex_data.py:31 - Finished fetching the new edflex data after 0:00:10.491522

edxapp@learning-tribes:~/edx-platform$ python manage.py lms fetch_edflex_data
2021-03-09 23:57:40,397 INFO 20880 [edflex_xblock] fetch_edflex_data.py:26 - Starting fetching the new edflex data...

edxapp@learning-tribes:~/edx-platform$ python manage.py lms update_resources
2021-03-09 23:59:43,033 INFO 21621 [edflex_xblock] update_resources.py:26 - Starting updating the resource data...
```